### PR TITLE
Implement cookie consent banner and analytics initialization

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,16 +1,15 @@
 {% if site.google_analytics %}
-	<!-- Google Analytics -->
+	<!-- Google Analytics (only loads if user has consented) -->
 	<script>
-		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-		ga('create', '{{ site.google_analytics }}', 'auto');
-		ga('send', 'pageview', {
-		  'page': '{{ site.baseurl }}{{ page.url }}',
-		  'title': '{{ page.title | replace: "'", "\\'" }}'
-		});
+		// We will initialize analytics only after user consent
+		// The initialization happens in cookie-consent.js
+		window.analyticsId = '{{ site.google_analytics }}';
+		
+		// If consent was already given and the page is being loaded/refreshed,
+		// the cookie-consent.js script will handle enabling analytics
+		
+		// This file intentionally doesn't load any analytics code directly
+		// All analytics initialization happens in cookie-consent.js after consent
 	</script>
 	<!-- End Google Analytics -->
 {% endif %}

--- a/_includes/cookie-banner.html
+++ b/_includes/cookie-banner.html
@@ -1,0 +1,15 @@
+<div id="cookie-banner" class="cookie-banner">
+  <div class="cookie-banner-content">
+    <div class="cookie-message">
+      This website uses cookies to ensure you get the best experience. By continuing to browse, you agree to our use of cookies.
+      <!-- Optionally add a link to privacy policy if you have one -->
+      {% if site.privacy_policy_url %}
+      <a href="{{ site.privacy_policy_url }}">Learn more</a>
+      {% endif %}
+    </div>
+    <div class="cookie-buttons">
+      <button id="cookie-accept" class="cookie-button cookie-accept">Accept</button>
+      <button id="cookie-decline" class="cookie-button cookie-decline">Decline</button>
+    </div>
+  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,18 +16,7 @@
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/style.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 
-    <!-- Created with Jekyll Now - http://github.com/barryclark/jekyll-now -->
-  </head>
-
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-RBFTZWJ8Z4"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-RBFTZWJ8Z4');
-  </script>
+    <!-- Created with Jekyll Now - http://github.com/barryclark/jekyll-now -->  </head>
 
   <body>
     <div class="wrapper-masthead">
@@ -62,8 +51,12 @@
          <div class="credits">this GitHub page is based on <a href="https://github.com/barryclark/jekyll-now" title="jekyll-now">jekyll-now</a></div>
         </footer>
       </div>
-    </div>
-
+    </div>    {% include cookie-banner.html %}
+    
+    <script>
+      window.analyticsId = '{{ site.google_analytics }}';
+    </script>
+    <script src="{{ site.baseurl }}/assets/js/cookie-consent.js"></script>
     {% include analytics.html %}
   </body>
 </html>

--- a/_sass/_cookie-consent.scss
+++ b/_sass/_cookie-consent.scss
@@ -1,0 +1,78 @@
+/* Cookie Consent Banner Styles */
+.cookie-banner {
+  position: fixed;
+  bottom: -100px;
+  left: 0;
+  width: 100%;
+  background-color: rgba(40, 40, 40, 0.95);
+  color: #fff;
+  padding: 15px 0;
+  text-align: center;
+  z-index: 1000;
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.2);
+  transition: bottom 0.5s ease-in-out;
+  font-size: 14px;
+}
+
+.cookie-banner.show {
+  bottom: 0;
+}
+
+.cookie-banner-content {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+}
+
+.cookie-message {
+  flex: 1;
+  text-align: left;
+  padding-right: 20px;
+}
+
+.cookie-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+.cookie-button {
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.3s;
+}
+
+.cookie-accept {
+  background-color: #4a90e2;
+  color: white;
+}
+
+.cookie-accept:hover {
+  background-color: #357ab8;
+}
+
+.cookie-decline {
+  background-color: transparent;
+  color: #ddd;
+  border: 1px solid #ddd;
+}
+
+.cookie-decline:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+@media (max-width: 768px) {
+  .cookie-banner-content {
+    flex-direction: column;
+  }
+  
+  .cookie-message {
+    padding-right: 0;
+    padding-bottom: 10px;
+  }
+}

--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -1,0 +1,95 @@
+/**
+ * Cookie consent functionality for ftnilsson.github.io
+ */
+(function() {
+  // Check if user has already made a cookie choice
+  function hasUserConsented() {
+    return localStorage.getItem('cookieConsent') === 'accepted';
+  }
+
+  function hasUserDeclined() {
+    return localStorage.getItem('cookieConsent') === 'declined';
+  }
+
+  // Save user choice to local storage
+  function saveConsent(choice) {
+    localStorage.setItem('cookieConsent', choice);
+  }
+
+  // Display the cookie banner if no choice has been made yet
+  function showCookieConsentBanner() {
+    if (!hasUserConsented() && !hasUserDeclined()) {
+      const banner = document.getElementById('cookie-banner');
+      if (banner) {
+        banner.classList.add('show');
+      }
+    }
+  }
+
+  // Handle accept button click
+  function handleAccept() {
+    saveConsent('accepted');
+    hideBanner();
+    enableAnalytics(); // Enable analytics after consent
+  }
+
+  // Handle decline button click
+  function handleDecline() {
+    saveConsent('declined');
+    hideBanner();
+  }
+
+  // Hide the banner
+  function hideBanner() {
+    const banner = document.getElementById('cookie-banner');
+    if (banner) {
+      banner.classList.remove('show');
+    }
+  }
+  // Enable Google Analytics
+  function enableAnalytics() {
+    const analyticsId = window.analyticsId;
+    if (!analyticsId) return;
+    
+    // Load Google Tag Manager script dynamically after consent
+    const gtagScript = document.createElement('script');
+    gtagScript.async = true;
+    gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${analyticsId}`;
+    document.head.appendChild(gtagScript);
+    
+    // Initialize gtag
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { window.dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', analyticsId);
+    
+    // Keep backwards compatibility with older analytics.js if it exists
+    if (typeof ga !== 'undefined') {
+      ga('create', analyticsId, 'auto');
+      ga('send', 'pageview');
+    }
+  }
+
+  // Initialize the banner when the DOM is loaded
+  document.addEventListener('DOMContentLoaded', function() {
+    // Check if we should show the banner
+    showCookieConsentBanner();
+
+    // Add event listeners to buttons
+    const acceptButton = document.getElementById('cookie-accept');
+    const declineButton = document.getElementById('cookie-decline');
+    
+    if (acceptButton) {
+      acceptButton.addEventListener('click', handleAccept);
+    }
+    
+    if (declineButton) {
+      declineButton.addEventListener('click', handleDecline);
+    }
+
+    // Enable analytics if consent was previously given
+    if (hasUserConsented()) {
+      enableAnalytics();
+    }
+  });
+})();

--- a/style.scss
+++ b/style.scss
@@ -8,6 +8,8 @@
 @import "reset";
 @import "variables";
 @import "tags";
+@import "related";
+@import "cookie-consent";
 // Syntax highlighting @import is at the bottom of this file
 
 /**************/
@@ -217,12 +219,6 @@ img {
   // font-weight: 400;
   font-size: 4rem;
   text-shadow: 0 0 2vw $lightPink;
-
-  a {
-    // animation: neon 1s ease infinite;
-    // -moz-animation: neon 1s ease infinite;
-    // -webkit-animation: neon 1s ease infinite;
-  }
   
   a:hover{
     color: $lightPink;


### PR DESCRIPTION
Add a cookie consent banner that informs users about cookie usage and allows them to accept or decline. Initialize Google Analytics only after user consent is granted. This ensures compliance with privacy regulations.